### PR TITLE
Fix missing `then` in uninstall.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A normal Raspbian sd card image also works well.
 (On a Raspberry Pi the script will even install dump1090-fa for you if it's not present)
 
 In case you don't want dump1090-fa to be installed/configured, you can download the script, and run it like this:
-```
+
+```shell
 sudo bash install.sh only-airspy
 ```
 
@@ -24,41 +25,49 @@ Generally readsb might be nicer than dump1090-fa. Just to reiterate, this needs 
 Or you can rerun this install script after installing readsb. You'll have to reconfigure airspy_adsb as this install overwrites the configuration.
 
 Content:
+
 * [Installation](https://github.com/wiedehopf/airspy-conf#installation)
 * [Other feeders](https://github.com/wiedehopf/airspy-conf#other-feeders)
 * [Changing airspy options](https://github.com/wiedehopf/airspy-conf#Changing-airspy_adsb-options)
 * [Uninstall](https://github.com/wiedehopf/airspy-conf#Uninstall)
 * [Update](https://github.com/wiedehopf/airspy-conf#Update)
+
 ---
 
-## Installation:
+## Installation
 
-```
+```shell
 sudo bash -c "$(wget -O - https://raw.githubusercontent.com/wiedehopf/airspy-conf/master/install.sh)"
 ```
+
 ---
-## Other feeders:
+
+## Other feeders
 
 While dump1090-fa can be used for this script and configuration to work, you don't have to install piaware.
 It should work fine with all the common feeders (fr24, planefinder, ...).
 Just point them to port 30005 (beast protocol).
 
 ---
+
 ## Changing airspy_adsb options
 
 If you want to change the airspy options, edit the option file:
 
-```
+```shell
 sudo nano /etc/default/airspy_adsb
 ```
 
 For example you might want to enable the bias tee, just add `-b` at the end of the options line so it looks like this:
-```
+
+```shell
 #other options
 OPTIONS= -f 1 -x -p -b
 ```
+
 There are other lines where you can change the gain or sample rate:
-```
+
+```shell
 #gain is 0 to 21, each step of gain is equivalent to about 3dB, so reduce in increments of 1 if 21 is too high
 GAIN=21
 
@@ -68,8 +77,9 @@ SAMPLE_RATE=12
 
 Ctrl-O and Enter/Return to save and Ctrl-X to exit
 
-Restart airspy_adsb with
-```
+Restart airspy_adsb with:
+
+```shell
 sudo systemctl restart airspy_adsb dump1090-fa
 ```
 
@@ -78,18 +88,22 @@ https://discussions.flightaware.com/t/howto-airspy-mini-and-airspy-r2-piaware-du
 
 If you have questions it is best to just post in that thread!
 
-## Uninstall:
+## Uninstall
 
 Disables the airspy_adsb service, restores the dump1090-fa configuration and resets the piaware configuration to the default:
-```
+
+```shell
 sudo bash -c "$(wget -O - https://raw.githubusercontent.com/wiedehopf/airspy-conf/master/uninstall.sh)"
 ```
+
 ---
 
-## Update:
+## Update
+
 Update / download airspy_adsb to /usr/local/bin while preserving options in /etc/default/airspy_adsb
 
-```
+```shell
 sudo bash -c "$(wget -O - https://raw.githubusercontent.com/wiedehopf/airspy-conf/master/update-binary.sh)"
 ```
-----
+
+---

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Simple configuration for using airspy_adsb with piaware or just dump1090-fa
+set -e
 
 repository=https://raw.githubusercontent.com/wiedehopf/airspy-conf/master
 #download and install the airspy_adsb binary
@@ -15,7 +16,7 @@ fi
 
 systemctl stop airspy_adsb &>/dev/null
 cd /tmp/
-if ! wget -q -O airspy.tgz $binary
+if ! wget -q -O airspy.tgz "$binary"
 then
 	echo "Unable to download a program version for your platform!"
 	exit 1
@@ -37,7 +38,7 @@ systemctl enable airspy_adsb
 systemctl restart airspy_adsb
 
 if [[ "$1" == "only-airspy" ]]; then
-	echo "airspy_adsb service installed.\n\
+	printf "airspy_adsb service installed.\n\
 	Listening on port 47787 to provide beast data.\n\
 	Trying to connect to port 30004 to provide beast data."
 	exit 0
@@ -63,7 +64,7 @@ else
 		apt update
 		if ! apt install dump1090-fa; then
 			echo " ----------"
-			echo "airspy_adsb service installed.\n\
+			printf "airspy_adsb service installed.\n\
 			Listening on port 47787 to provide beast data.\n\
 			Trying to connect to port 30004 to provide beast data."
 			echo " ----------"

--- a/install.sh
+++ b/install.sh
@@ -4,11 +4,9 @@ set -e
 
 repository=https://raw.githubusercontent.com/wiedehopf/airspy-conf/master
 #download and install the airspy_adsb binary
-if uname -m | grep -F -e arm64 -e aarch64 &>/dev/null
-then
+if uname -m | grep -F -e arm64 -e aarch64 &>/dev/null; then
 	binary="https://airspy.com/downloads/airspy_adsb-linux-arm64.tgz"
-elif uname -m | grep -F -e arm &>/dev/null
-then
+elif uname -m | grep -F -e arm &>/dev/null; then
 	binary="https://airspy.com/downloads/airspy_adsb-linux-arm.tgz"
 else
 	binary="https://airspy.com/downloads/airspy_adsb-linux-$(uname -m).tgz"
@@ -16,14 +14,12 @@ fi
 
 systemctl stop airspy_adsb &>/dev/null
 cd /tmp/
-if ! wget -q -O airspy.tgz "$binary"
-then
+if ! wget -q -O airspy.tgz "$binary"; then
 	echo "Unable to download a program version for your platform!"
 	exit 1
 fi
 tar xzf airspy.tgz
 cp airspy_adsb /usr/local/bin/
-
 
 #install and enable systemd service
 rm -f /etc/systemd/system/airspy_adsb.service
@@ -44,8 +40,7 @@ if [[ "$1" == "only-airspy" ]]; then
 	exit 0
 fi
 
-if [ -f /boot/piaware-config.txt ]
-then
+if [ -f /boot/piaware-config.txt ]; then
 	#configure piaware to custom mode
 	#sed -i -e 's@beast - radarcape - relay - other@# added by airspy\n\t\tother {\n\t\t\tlappend receiverOpts "--net-only" "--net-bo-port 30005" "--fix"\n\t\t}\n\n\t\tbeast - radarcape - relay@' /usr/lib/piaware-support/generate-receiver-config
 	#piaware version > 3.7
@@ -56,8 +51,7 @@ then
 	piaware-config receiver-port 47787
 else
 	#package install, install dump1090-fa
-	if ! command -v dump1090-fa &>/dev/null && ! command -v readsb &>/dev/null
-	then
+	if ! command -v dump1090-fa &>/dev/null && ! command -v readsb &>/dev/null; then
 		echo 'Installing dump1090-fa as it is required:'
 		wget -q http://flightaware.com/adsb/piaware/files/packages/pool/piaware/p/piaware-support/piaware-repository_3.7.2_all.deb
 		dpkg -i piaware-repository_3.7.2_all.deb
@@ -81,8 +75,7 @@ else
 		LON=$(grep -o -e '--lon [0-9]*\.[0-9]*' /etc/default/dump1090-fa | head -n1)
 		cp -n /etc/default/dump1090-fa /etc/default/dump1090-fa.airspyconf
 		wget -q -O /etc/default/dump1090-fa $repository/dump1090-fa.default
-		if [ -n "$LAT" ] && [ -n "$LON" ]
-		then
+		if [ -n "$LAT" ] && [ -n "$LON" ]; then
 			sed -i "s/DECODER_OPTIONS=\"/DECODER_OPTIONS=\"$LAT $LON /" /etc/default/dump1090-fa
 		fi
 	elif command -v readsb &>/dev/null; then
@@ -90,8 +83,7 @@ else
 		LON=$(grep -o -e '--lon [0-9]*\.[0-9]*' /etc/default/readsb | head -n1)
 		cp -n /etc/default/readsb /etc/default/readsb.airspyconf
 		wget -q -O /etc/default/readsb $repository/dump1090-fa.default
-		if [ -n "$LAT" ] && [ -n "$LON" ]
-		then
+		if [ -n "$LAT" ] && [ -n "$LON" ]; then
 			sed -i "s/DECODER_OPTIONS=\"/DECODER_OPTIONS=\"$LAT $LON /" /etc/default/readsb
 		fi
 	else
@@ -99,7 +91,6 @@ else
 	fi
 
 fi
-
 
 #restart relevant services
 systemctl daemon-reload

--- a/restart_airspy_adsb
+++ b/restart_airspy_adsb
@@ -4,5 +4,5 @@ systemctl restart airspy_adsb
 	systemctl stop beast-splitter &>/dev/null
 	sleep 10
 	systemctl start beast-splitter &>/dev/null
-)&
+) &
 exit 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,19 +3,16 @@ set -e
 
 mv /etc/default/dump1090-fa.airspyconf /etc/default/dump1090-fa
 
-if [ -f /usr/lib/piaware-support/generate-receiver-config ]
-then
-	sed -i -e '/# added by airspy/,+4d' /usr/lib/piaware-support/generate-receiver-config
-	sed -i -e 's/beast - radarcape - relay/beast - radarcape - relay - other/' /usr/lib/piaware-support/generate-receiver-config
+if [ -f /usr/lib/piaware-support/generate-receiver-config ]; then
+    sed -i -e '/# added by airspy/,+4d' /usr/lib/piaware-support/generate-receiver-config
+    sed -i -e 's/beast - radarcape - relay/beast - radarcape - relay - other/' /usr/lib/piaware-support/generate-receiver-config
 fi
 
-if [ -f /boot/piaware-config.txt ]
-then
+if [ -f /boot/piaware-config.txt ]; then
     piaware-config receiver-type ""
     piaware-config receiver-host "127.0.0.1"
     piaware-config receiver-port "30005"
 fi
-
 
 systemctl disable airspy_adsb
 systemctl stop airspy_adsb

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 mv /etc/default/dump1090-fa.airspyconf /etc/default/dump1090-fa
 
@@ -9,6 +10,7 @@ then
 fi
 
 if [ -f /boot/piaware-config.txt ]
+then
     piaware-config receiver-type ""
     piaware-config receiver-host "127.0.0.1"
     piaware-config receiver-port "30005"

--- a/update-binary.sh
+++ b/update-binary.sh
@@ -2,19 +2,16 @@
 # Update airspy_adsb binary
 set -e
 
-if uname -m | grep -F -e arm64 -e aarch64 &>/dev/null
-then
+if uname -m | grep -F -e arm64 -e aarch64 &>/dev/null; then
 	binary="https://airspy.com/downloads/airspy_adsb-linux-arm64.tgz"
-elif uname -m | grep -F -e arm &>/dev/null
-then
+elif uname -m | grep -F -e arm &>/dev/null; then
 	binary="https://airspy.com/downloads/airspy_adsb-linux-arm.tgz"
 else
 	binary="https://airspy.com/downloads/airspy_adsb-linux-$(uname -m).tgz"
 fi
 
 cd /tmp/
-if ! wget -O airspy.tgz "$binary"
-then
+if ! wget -O airspy.tgz "$binary"; then
 	echo "Unable to download a program version for your platform!"
 	exit 1
 fi

--- a/update-binary.sh
+++ b/update-binary.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Update airspy_adsb binary
+set -e
 
 if uname -m | grep -F -e arm64 -e aarch64 &>/dev/null
 then
@@ -12,7 +13,7 @@ else
 fi
 
 cd /tmp/
-if ! wget -O airspy.tgz $binary
+if ! wget -O airspy.tgz "$binary"
 then
 	echo "Unable to download a program version for your platform!"
 	exit 1


### PR DESCRIPTION
Hey,

I had the following error when I used the uninstall.sh script:

```
bash: -c: line 14: syntax error near unexpected token `fi'
bash: -c: line 14: `fi'
```

I fix it and took the opportunity to run shellcheck, markdownlint, and to format sh files.


