### PR TITLE
feature: run airspy_adsb service as unprivileged user

### DIFF
--- a/airspy_adsb.rules
+++ b/airspy_adsb.rules
@@ -1,0 +1,4 @@
+# added by https://github.com/wiedehopf/airspy-conf/blob/master/install.sh
+
+# Airspy Mini
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a1", MODE:="0660", GROUP:="plugdev"

--- a/airspy_adsb.service
+++ b/airspy_adsb.service
@@ -10,7 +10,7 @@ EnvironmentFile=/etc/default/airspy_adsb
 ExecStart=/usr/bin/taskset -c $AFFINITY /usr/local/bin/airspy_adsb $OPTIONS $NET $G $GAIN $M $SAMPLE_RATE $STATS
 
 SyslogIdentifier=airspy_adsb
-User=root
+User=airspy_adsb
 
 Nice=-19
 

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,16 @@ repository=https://raw.githubusercontent.com/wiedehopf/airspy-conf/master
 systemctl stop airspy_adsb &>/dev/null || true
 cp -f airspy_adsb /usr/local/bin/
 
+# create user incl. group
+adduser --system --comment "Unprivileged user for running airspy_adsb" airspy_adsb
+adduser airspy_adsb plugdev
+
+# install udev rules for airspy
+rm -f /etc/udev/rules.d/airspy_adsb.rules
+wget -q -O /etc/udev/rules.d/airspy_adsb.rules $repository/airspy_adsb.rules
+udevadm control --reload-rules
+udevadm trigger
+
 #install and enable systemd service
 rm -f /etc/systemd/system/airspy_adsb.service
 wget -q -O /lib/systemd/system/airspy_adsb.service $repository/airspy_adsb.service

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -25,5 +25,11 @@ systemctl is-enabled piaware &>/dev/null && systemctl restart --no-block piaware
 systemctl is-enabled dump1090-fa &>/dev/null && systemctl restart --no-block dump1090-fa || true
 systemctl is-enabled readsb &>/dev/null && systemctl restart --no-block readsb || true
 
+rm -f /etc/udev/rules.d/airspy_adsb.rules
+udevadm control --reload-rules
+udevadm trigger
+
+deluser airspy_adsb
+
 echo "------------------------"
 echo "airspy-conf uninstall finished successfully!"


### PR DESCRIPTION
So this is the continuation of #7 - with the help of @wiedehopf, i experimented a little bit and found out, that the udev rule was actually the correct hint. Further i found out, that a memberhip in the `plugdev` group is not required in my case.

The result is this PR. I am currently waiting for some `lsusb` outputs of some friends, to ensure, that the Vendor and Product ID in my udev rule is correct and universally usable. If i am sure, i will mark this PR as ready.

Of course, i am also open for `lsusb`-Outputs and feedback about my proposed changes right here.